### PR TITLE
[MSHARED-850] Upgrade org.eclipse.aether:aether-util dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,13 +86,13 @@
     <dependency>
       <groupId>org.eclipse.aether</groupId>
       <artifactId>aether-api</artifactId>
-      <version>0.9.0.M2</version>
+      <version>1.1.0</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.eclipse.aether</groupId>
       <artifactId>aether-util</artifactId>
-      <version>0.9.0.M2</version>
+      <version>1.1.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.aether</groupId>


### PR DESCRIPTION
Upgrade org.eclipse.aether:aether-util dependency in org.apache.maven.shared:maven-dependency-tree.

1.1.0 is the latest in https://search.maven.org/search?q=g:org.eclipse.aether%20AND%20a:aether-util. The artifact has public `ChecksumUtils.toHexString` which would avoid the error in https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1091.