### PR TITLE
[MSHARED-1016] - exclude transitive provided scope dependencies

### DIFF
--- a/src/main/java/org/apache/maven/shared/dependency/graph/internal/Maven31DependencyCollectorBuilder.java
+++ b/src/main/java/org/apache/maven/shared/dependency/graph/internal/Maven31DependencyCollectorBuilder.java
@@ -106,6 +106,7 @@ public class Maven31DependencyCollectorBuilder
 
             DependencySelector depFilter =
                 new AndDependencySelector( new Maven31DirectScopeDependencySelector( JavaScopes.TEST ),
+                                           new Maven31DirectScopeDependencySelector( JavaScopes.PROVIDED ),
                                            new OptionalDependencySelector(),
                                            new ExclusionDependencySelector() );
             session.setDependencySelector( depFilter );

--- a/src/main/java/org/apache/maven/shared/dependency/graph/internal/Maven3DependencyCollectorBuilder.java
+++ b/src/main/java/org/apache/maven/shared/dependency/graph/internal/Maven3DependencyCollectorBuilder.java
@@ -106,6 +106,7 @@ public class Maven3DependencyCollectorBuilder
 
             DependencySelector depFilter =
                 new AndDependencySelector( new Maven3DirectScopeDependencySelector( JavaScopes.TEST ),
+                                           new Maven3DirectScopeDependencySelector( JavaScopes.PROVIDED ),
                                            new OptionalDependencySelector(), 
                                            new ExclusionDependencySelector() );
             session.setDependencySelector( depFilter );


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MSHARED-1016

Transitive dependencies with provided scope should be excluded in order to match maven behavior:

https://github.com/apache/maven/blob/706d9319f14b507f3c3deeba4eeda1a51a531c9b/maven-resolver-provider/src/main/java/org/apache/maven/repository/internal/MavenRepositorySystemUtils.java#L80

This should resolve https://issues.apache.org/jira/browse/MENFORCER-402 and provide a better fix for https://issues.apache.org/jira/browse/MENFORCER-394.
