### PR TITLE
[MSHARED-1286] Display if dependency is optional in tree

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,13 @@
       <version>1</version>
       <optional>true</optional>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.9.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/it/display-optional-information/expected.txt
+++ b/src/it/display-optional-information/expected.txt
@@ -1,0 +1,7 @@
+org.apache.maven.its.dependency-tree:test:jar:1.0-SNAPSHOT
++- org.apache.maven:maven-settings:jar:2.0.6:compile
+|  +- org.codehaus.plexus:plexus-utils:jar:1.4.1:compile
+|  \- org.codehaus.plexus:plexus-container-default:jar:1.0-alpha-9-stable-1:compile
+|     +- junit:junit:jar:3.8.1:compile
+|     \- classworlds:classworlds:jar:1.1-alpha-2:compile
+\- org.apache.maven:maven-model:jar:2.0.5:compile (optional)

--- a/src/it/display-optional-information/invoker.properties
+++ b/src/it/display-optional-information/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = org.apache.maven.its.dependency-tree:graph-maven-plugin:graph

--- a/src/it/display-optional-information/pom.xml
+++ b/src/it/display-optional-information/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.dependency-tree</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>Test</name>
+  <description>
+    Test dependency-tree with actual Maven version through dependency:tree (easier than shade, or MPIR:dependencies).
+    Needs to be run in sequence with Maven 2.2.1, 3.0.x and 3.1-alpha-1+ to check the 3 graph API implementations.
+  </description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-settings</artifactId>
+      <version>2.0.6</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-model</artifactId>
+      <version>2.0.5</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.its.dependency-tree</groupId>
+          <artifactId>graph-maven-plugin</artifactId>
+          <version>1.0-SNAPSHOT</version>
+          <configuration>
+            <outputFile>target/tree.txt</outputFile>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/src/it/display-optional-information/verify.groovy
+++ b/src/it/display-optional-information/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+actual = new File( basedir, "target/tree.txt" ).readLines()
+expected = new File( basedir, "expected.txt" ).readLines()
+assert actual.equals( expected )

--- a/src/main/java/org/apache/maven/shared/dependency/graph/internal/DefaultDependencyGraphBuilder.java
+++ b/src/main/java/org/apache/maven/shared/dependency/graph/internal/DefaultDependencyGraphBuilder.java
@@ -129,7 +129,7 @@ public class DefaultDependencyGraphBuilder implements DependencyGraphBuilder {
         String premanagedScope = DependencyManagerUtils.getPremanagedScope(node);
 
         List<org.apache.maven.model.Exclusion> exclusions = null;
-        Boolean optional = null;
+        Boolean optional = artifact.isOptional();
         if (node.getDependency() != null) {
             exclusions = new ArrayList<>(node.getDependency().getExclusions().size());
             for (Exclusion exclusion : node.getDependency().getExclusions()) {

--- a/src/main/java/org/apache/maven/shared/dependency/graph/internal/DefaultDependencyNode.java
+++ b/src/main/java/org/apache/maven/shared/dependency/graph/internal/DefaultDependencyNode.java
@@ -175,6 +175,6 @@ public class DefaultDependencyNode implements DependencyNode {
      */
     @Override
     public String toNodeString() {
-        return String.valueOf(artifact);
+        return artifact + (Boolean.TRUE.equals(optional) ? " (optional)" : "");
     }
 }

--- a/src/test/java/org/apache/maven/shared/dependency/graph/internal/DefaultDependencyNodeTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/graph/internal/DefaultDependencyNodeTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.shared.dependency.graph.internal;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.junit.jupiter.api.Test;
+
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DefaultDependencyNodeTest {
+
+    private final Artifact artifact = new DefaultArtifact("group", "artifact", "1.2", "compile", "jar", "", null);
+
+    @Test
+    public void nodeString_should_display_if_dependency_is_optonal() {
+        DefaultDependencyNode optionalNode =
+                new DefaultDependencyNode(null, artifact, "1.0", "compile", "1.0", true, emptyList());
+        assertEquals("group:artifact:jar:1.2:compile (optional)", optionalNode.toNodeString());
+    }
+
+    @Test
+    public void nodeString_for_mandatory_depenendency_does_not_contain_optional_information() {
+        DefaultDependencyNode optionalNode =
+                new DefaultDependencyNode(null, artifact, "1.0", "compile", "1.0", false, emptyList());
+        assertEquals("group:artifact:jar:1.2:compile", optionalNode.toNodeString());
+    }
+}


### PR DESCRIPTION
This should reintroduce that dependency:tree shows if a dependency is optional which was removed in 3.3.0 of dependency plugin.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/MSHARED) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[MSHARED-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MSHARED-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

