### PR TITLE
[MSHARED-1454] Expose ConflictData on DependencyNode

### DIFF
--- a/src/main/java/org/apache/maven/shared/dependency/graph/ConflictData.java
+++ b/src/main/java/org/apache/maven/shared/dependency/graph/ConflictData.java
@@ -49,7 +49,7 @@ public class ConflictData {
     /**
      * In case of a conflict, the version of the dependency that was selected.
      *
-     * @return the version of the dependency node that was selected.
+     * @return the version of the dependency node that was selected
      */
     public String getWinnerVersion() {
         return winnerVersion;

--- a/src/main/java/org/apache/maven/shared/dependency/graph/ConflictData.java
+++ b/src/main/java/org/apache/maven/shared/dependency/graph/ConflictData.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.shared.dependency.graph.internal;
+package org.apache.maven.shared.dependency.graph;
 
 /**
  * Explicit subset of Aether's DependencyNode.getData().

--- a/src/main/java/org/apache/maven/shared/dependency/graph/ConflictData.java
+++ b/src/main/java/org/apache/maven/shared/dependency/graph/ConflictData.java
@@ -26,11 +26,7 @@ package org.apache.maven.shared.dependency.graph;
 public class ConflictData {
     private String winnerVersion;
 
-    private String originalScope;
-
     private String ignoredScope;
-
-    private Boolean originalOptionality;
 
     /**
      * Construct ConflictData. Containing information about conflicts during dependency resolution.
@@ -53,42 +49,6 @@ public class ConflictData {
      */
     public String getWinnerVersion() {
         return winnerVersion;
-    }
-
-    /**
-     * Original scope of a rejected dependency due to a conflict.
-     *
-     * @return the original scope of the dependency that was updated from
-     */
-    public String getOriginalScope() {
-        return originalScope;
-    }
-
-    /**
-     * Set original scope of a rejected dependency due to a conflict.
-     *
-     * @param originalScope the original scope of the dependency that was updated from
-     */
-    public void setOriginalScope(String originalScope) {
-        this.originalScope = originalScope;
-    }
-
-    /**
-     * Original optionality of a rejected dependency due to a conflict.
-     *
-     * @return the original optionality of the dependency
-     */
-    public Boolean getOriginalOptionality() {
-        return originalOptionality;
-    }
-
-    /**
-     * Set original optionality of a rejected dependency due to a conflict.
-     *
-     * @param originalOptionality the original optionality of the dependency
-     */
-    public void setOriginalOptionality(Boolean originalOptionality) {
-        this.originalOptionality = originalOptionality;
     }
 
     /**

--- a/src/main/java/org/apache/maven/shared/dependency/graph/ConflictData.java
+++ b/src/main/java/org/apache/maven/shared/dependency/graph/ConflictData.java
@@ -30,16 +30,16 @@ public class ConflictData {
 
     private String ignoredScope;
 
-    private Boolean originaOptionality;
+    private Boolean originalOptionality;
 
     /**
      * Construct ConflictData. Containing information about conflicts during dependency resolution.
-     * Either this node lost the conflict and winnerVersion is set with the versionwof the winnig node,
+     * Either this node lost the conflict and winnerVersion is set with the version of the winnig node,
      * or this node won and winnerVersion is @code{null}.
-     * If this node won ignoredScope can contain potential scopes that were ignored during conflict resolution.
+     * If this node won, ignoredScope can contain potential scopes that were ignored during conflict resolution.
      *
-     * @param winnerVersion the version of the dependency that was selected.
-     * @param ignoredScope  the scope
+     * @param winnerVersion the version of the dependency that was selected
+     * @param ignoredScope  the scope of the dependency that was ignored and not updated to
      */
     public ConflictData(String winnerVersion, String ignoredScope) {
         this.winnerVersion = winnerVersion;
@@ -58,7 +58,7 @@ public class ConflictData {
     /**
      * Original scope of a rejected dependency due to a conflict.
      *
-     * @return the original scope of the dependency that was updated from.
+     * @return the original scope of the dependency that was updated from
      */
     public String getOriginalScope() {
         return originalScope;
@@ -67,7 +67,7 @@ public class ConflictData {
     /**
      * Set original scope of a rejected dependency due to a conflict.
      *
-     * @param originalScope the original scope of the dependency that was updated from.
+     * @param originalScope the original scope of the dependency that was updated from
      */
     public void setOriginalScope(String originalScope) {
         this.originalScope = originalScope;
@@ -76,25 +76,25 @@ public class ConflictData {
     /**
      * Original optionality of a rejected dependency due to a conflict.
      *
-     * @return the original optionality of the dependency.
+     * @return the original optionality of the dependency
      */
-    public Boolean getOriginaOptionality() {
-        return originaOptionality;
+    public Boolean getOriginalOptionality() {
+        return originalOptionality;
     }
 
     /**
      * Set original optionality of a rejected dependency due to a conflict.
      *
-     * @param originaOptionality the original optionality of the dependency.
+     * @param originalOptionality the original optionality of the dependency
      */
-    public void setOriginaOptionality(Boolean originaOptionality) {
-        this.originaOptionality = originaOptionality;
+    public void setOriginalOptionality(Boolean originalOptionality) {
+        this.originalOptionality = originalOptionality;
     }
 
     /**
      * The scope of the dependency that was not updated to during dependency resolution.
      *
-     * @return the scope of the dependency that was ignored and not updated to.
+     * @return the scope of the dependency that was ignored and not updated to
      */
     public String getIgnoredScope() {
         return ignoredScope;

--- a/src/main/java/org/apache/maven/shared/dependency/graph/ConflictData.java
+++ b/src/main/java/org/apache/maven/shared/dependency/graph/ConflictData.java
@@ -32,31 +32,70 @@ public class ConflictData {
 
     private Boolean originaOptionality;
 
+    /**
+     * Construct ConflictData. Containing information about conflicts during dependency resolution.
+     * Either this node lost the conflict and winnerVersion is set with the versionwof the winnig node,
+     * or this node won and winnerVersion is @code{null}.
+     * If this node won ignoredScope can contain potential scopes that were ignored during conflict resolution.
+     *
+     * @param winnerVersion the version of the dependency that was selected.
+     * @param ignoredScope  the scope
+     */
     public ConflictData(String winnerVersion, String ignoredScope) {
         this.winnerVersion = winnerVersion;
         this.ignoredScope = ignoredScope;
     }
 
+    /**
+     * In case of a conflict, the version of the dependency that was selected.
+     *
+     * @return the version of the dependency node that was selected.
+     */
     public String getWinnerVersion() {
         return winnerVersion;
     }
 
+    /**
+     * Original scope of a rejected dependency due to a conflict.
+     *
+     * @return the original scope of the dependency that was updated from.
+     */
     public String getOriginalScope() {
         return originalScope;
     }
 
+    /**
+     * Set original scope of a rejected dependency due to a conflict.
+     *
+     * @param originalScope the original scope of the dependency that was updated from.
+     */
     public void setOriginalScope(String originalScope) {
         this.originalScope = originalScope;
     }
 
+    /**
+     * Original optionality of a rejected dependency due to a conflict.
+     *
+     * @return the original optionality of the dependency.
+     */
     public Boolean getOriginaOptionality() {
         return originaOptionality;
     }
 
+    /**
+     * Set original optionality of a rejected dependency due to a conflict.
+     *
+     * @param originaOptionality the original optionality of the dependency.
+     */
     public void setOriginaOptionality(Boolean originaOptionality) {
         this.originaOptionality = originaOptionality;
     }
 
+    /**
+     * The scope of the dependency that was not updated to during dependency resolution.
+     *
+     * @return the scope of the dependency that was ignored and not updated to.
+     */
     public String getIgnoredScope() {
         return ignoredScope;
     }

--- a/src/main/java/org/apache/maven/shared/dependency/graph/DependencyNode.java
+++ b/src/main/java/org/apache/maven/shared/dependency/graph/DependencyNode.java
@@ -97,4 +97,11 @@ public interface DependencyNode {
      * @return the exclusions of the dependency
      */
     List<Exclusion> getExclusions();
+
+    /**
+     * If this is a verbose dependency node, this returns the conflict data. Otherwise, it returns null.
+     *
+     * @return the conflict data of verbose dependency node or null
+     */
+    ConflictData getConflictData();
 }

--- a/src/main/java/org/apache/maven/shared/dependency/graph/internal/DefaultDependencyCollectorBuilder.java
+++ b/src/main/java/org/apache/maven/shared/dependency/graph/internal/DefaultDependencyCollectorBuilder.java
@@ -33,6 +33,7 @@ import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.shared.dependency.graph.ConflictData;
 import org.apache.maven.shared.dependency.graph.DependencyCollectorBuilder;
 import org.apache.maven.shared.dependency.graph.DependencyCollectorBuilderException;
 import org.apache.maven.shared.dependency.graph.DependencyCollectorRequest;

--- a/src/main/java/org/apache/maven/shared/dependency/graph/internal/DefaultDependencyNode.java
+++ b/src/main/java/org/apache/maven/shared/dependency/graph/internal/DefaultDependencyNode.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Exclusion;
+import org.apache.maven.shared.dependency.graph.ConflictData;
 import org.apache.maven.shared.dependency.graph.DependencyNode;
 import org.apache.maven.shared.dependency.graph.traversal.DependencyNodeVisitor;
 
@@ -176,5 +177,10 @@ public class DefaultDependencyNode implements DependencyNode {
     @Override
     public String toNodeString() {
         return artifact + (Boolean.TRUE.equals(optional) ? " (optional)" : "");
+    }
+
+    @Override
+    public ConflictData getConflictData() {
+        return null;
     }
 }

--- a/src/main/java/org/apache/maven/shared/dependency/graph/internal/VerboseDependencyNode.java
+++ b/src/main/java/org/apache/maven/shared/dependency/graph/internal/VerboseDependencyNode.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Exclusion;
+import org.apache.maven.shared.dependency.graph.ConflictData;
 import org.apache.maven.shared.dependency.graph.DependencyNode;
 
 class VerboseDependencyNode extends DefaultDependencyNode {
@@ -94,6 +95,11 @@ class VerboseDependencyNode extends DefaultDependencyNode {
         }
 
         return buffer.toString();
+    }
+
+    @Override
+    public ConflictData getConflictData() {
+        return data;
     }
 
     /**

--- a/src/main/java/org/apache/maven/shared/dependency/graph/internal/VerboseDependencyNode.java
+++ b/src/main/java/org/apache/maven/shared/dependency/graph/internal/VerboseDependencyNode.java
@@ -65,10 +65,6 @@ class VerboseDependencyNode extends DefaultDependencyNode {
             appender.append("scope managed from ", getPremanagedScope());
         }
 
-        if (data.getOriginalScope() != null) {
-            appender.append("scope updated from ", data.getOriginalScope());
-        }
-
         if (data.getIgnoredScope() != null) {
             appender.append("scope not updated to ", data.getIgnoredScope());
         }

--- a/src/test/java/org/apache/maven/shared/dependency/graph/internal/DefaultDependencyNodeTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/graph/internal/DefaultDependencyNodeTest.java
@@ -45,7 +45,7 @@ public class DefaultDependencyNodeTest {
     }
 
     @Test
-    public void defaultDependencyNode_should_return_null_conflict_data() {
+    public void defaultDependencyNodeHasNullConflictData() {
         DefaultDependencyNode node =
                 new DefaultDependencyNode(null, artifact, "1.0", "compile", "1.0", false, emptyList());
 

--- a/src/test/java/org/apache/maven/shared/dependency/graph/internal/DefaultDependencyNodeTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/graph/internal/DefaultDependencyNodeTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class DefaultDependencyNodeTest {
 
@@ -48,6 +49,6 @@ public class DefaultDependencyNodeTest {
         DefaultDependencyNode node =
                 new DefaultDependencyNode(null, artifact, "1.0", "compile", "1.0", false, emptyList());
 
-        assertEquals(node.getConflictData(), null);
+        assertNull(node.getConflictData());
     }
 }

--- a/src/test/java/org/apache/maven/shared/dependency/graph/internal/VerboseDependencyNodeTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/graph/internal/VerboseDependencyNodeTest.java
@@ -36,7 +36,7 @@ public class VerboseDependencyNodeTest {
         VerboseDependencyNode verboseDependencyNode =
                 new VerboseDependencyNode(null, artifact, "1.0", "compile", "1.0", false, emptyList(), conflictData);
 
-        assertEquals(verboseDependencyNode.getConflictData().getWinnerVersion(), "winnerVersion");
-        assertEquals(verboseDependencyNode.getConflictData().getIgnoredScope(), "ignoredScope");
+        assertEquals("winnerVersion", verboseDependencyNode.getConflictData().getWinnerVersion());
+        assertEquals("ignoredScope", verboseDependencyNode.getConflictData().getIgnoredScope());
     }
 }

--- a/src/test/java/org/apache/maven/shared/dependency/graph/internal/VerboseDependencyNodeTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/graph/internal/VerboseDependencyNodeTest.java
@@ -20,34 +20,23 @@ package org.apache.maven.shared.dependency.graph.internal;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.shared.dependency.graph.ConflictData;
 import org.junit.jupiter.api.Test;
 
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class DefaultDependencyNodeTest {
+public class VerboseDependencyNodeTest {
 
     private final Artifact artifact = new DefaultArtifact("group", "artifact", "1.2", "compile", "jar", "", null);
 
     @Test
-    public void nodeString_should_display_if_dependency_is_optonal() {
-        DefaultDependencyNode optionalNode =
-                new DefaultDependencyNode(null, artifact, "1.0", "compile", "1.0", true, emptyList());
-        assertEquals("group:artifact:jar:1.2:compile (optional)", optionalNode.toNodeString());
-    }
+    public void verboseDependencyNode_should_return_conflict_data() {
+        ConflictData conflictData = new ConflictData("winnerVersion", "ignoredScope");
+        VerboseDependencyNode verboseDependencyNode =
+                new VerboseDependencyNode(null, artifact, "1.0", "compile", "1.0", false, emptyList(), conflictData);
 
-    @Test
-    public void nodeString_for_mandatory_depenendency_does_not_contain_optional_information() {
-        DefaultDependencyNode optionalNode =
-                new DefaultDependencyNode(null, artifact, "1.0", "compile", "1.0", false, emptyList());
-        assertEquals("group:artifact:jar:1.2:compile", optionalNode.toNodeString());
-    }
-
-    @Test
-    public void defaultDependencyNode_should_return_null_conflict_data() {
-        DefaultDependencyNode node =
-                new DefaultDependencyNode(null, artifact, "1.0", "compile", "1.0", false, emptyList());
-
-        assertEquals(node.getConflictData(), null);
+        assertEquals(verboseDependencyNode.getConflictData().getWinnerVersion(), "winnerVersion");
+        assertEquals(verboseDependencyNode.getConflictData().getIgnoredScope(), "ignoredScope");
     }
 }


### PR DESCRIPTION
Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/MSHARED) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MSHARED-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MSHARED-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

-------


In maven-dependency-plugin there are multiple export formats for the dependency tree, these include Json, DOT, GraphML etc. When creating the normal tree all information is there to format it nicely as e.g. Json. However, when running `mvn dependency:tree -Dverbose`, all nodes are included (as they are VerboseDependencyNode) but since VerboseDependencyNode is internal in maven-dependency-tree there is no (clean) way to include information of which nodes are included or not (see [https://issues.apache.org/jira/browse/MDEP-962](https://issues.apache.org/jira/browse/MDEP-962)).

The only current way to include this information would be to parse the `toNodeString()` output (where excluded nodes are wrapped in parenthesis).

I propose to expose ConflictData on the DependencyNode and make it null for DefaultDependencyNode to allow for more detailed information in the machine-readable formats.

